### PR TITLE
Update chat_request.py

### DIFF
--- a/src/chat_request.py
+++ b/src/chat_request.py
@@ -30,7 +30,13 @@ def get_embedding(question: str):
 def get_response(question, chat_history):
     print("inputs:", question)
     embedding = get_embedding(question)
+    if embedding is None:
+        raise ValueError("Embedding is None, cannot proceed further.")
+    
     context = get_context(question, embedding)
+    if context is None:
+        raise ValueError("Context is None, cannot proceed further.")
+    
     print("context:", context)
     print("getting result...")
 


### PR DESCRIPTION
The error occurs due to an unsupported operand type for the '+' operation between an 'int' and 'NoneType' in the get_response function. This indicates that one of the variables involved in the addition operation is None.

Possible Fixes
Ensure that get_embedding and get_context functions return valid results. Add checks to handle None values before performing operations. Add validation for the inputs to get_response to ensure they are not None.